### PR TITLE
Revert "Bump Serilog.Extensions.Hosting from 5.0.0 to 5.0.1 (#6)"

### DIFF
--- a/TheOmenDen.Shared.csproj
+++ b/TheOmenDen.Shared.csproj
@@ -79,7 +79,7 @@
     <PackageReference Include="Scrutor" Version="4.2.0" />
     <PackageReference Include="Serilog" Version="2.11.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.0.0" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Extensions.Logging.File" Version="3.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />


### PR DESCRIPTION
This reverts commit 7dce0edb22fa3d62a0a1ebe428e7cb3d7d531984.